### PR TITLE
Bugfix - vars as ref

### DIFF
--- a/wp-relationships/includes/functions/common.php
+++ b/wp-relationships/includes/functions/common.php
@@ -45,7 +45,8 @@ function wp_relationships_admin_url( $args = array() ) {
  * @return array
  */
 function wp_relationships_get_object( $args = array(), $operator = 'AND' ) {
-	return reset( wp_relationships_get_objects( $args, $operator ) );
+	$reset = wp_relationships_get_objects( $args, $operator );
+	return reset( $reset );
 }
 
 /**


### PR DESCRIPTION
Following notice found on the Edit Post page on wp-admin. Think might be stricter PHP standards in PHP7. Not 100% sure. Fixed though.

( ! ) Notice: Only variables should be passed by reference in /app/public/wp-content/plugins/wp-relationships/wp-relationships/includes/functions/common.php on line 48